### PR TITLE
fix: improve error handling and fix RTCRtpSender edge case

### DIFF
--- a/src/aiortc/__init__.py
+++ b/src/aiortc/__init__.py
@@ -50,7 +50,7 @@ from .stats import (
     RTCTransportStats,
 )
 
-__version__ = "1.13.0"
+__version__ = "1.13.0a2"
 
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -231,13 +231,13 @@ class PlayerStreamTrack(MediaStreamTrack):
 
     async def recv(self) -> Union[Frame, Packet]:
         if self.readyState != "live":
-            raise MediaStreamError
+            raise MediaStreamError("PlayerStreamTrack is not in 'live' state")
 
         self._player._start(self)
         data = await self._queue.get()
         if data is None:
             self.stop()
-            raise MediaStreamError
+            raise MediaStreamError("PlayerStreamTrack received end of stream")
         if isinstance(data, Frame):
             data_time = data.time
         elif isinstance(data, Packet):
@@ -537,7 +537,7 @@ class RelayStreamTrack(MediaStreamTrack):
 
     async def recv(self) -> Union[Frame, Packet]:
         if self.readyState != "live":
-            raise MediaStreamError
+            raise MediaStreamError("RelayStreamTrack is not in 'live' state")
 
         self._relay._start(self)
 
@@ -549,7 +549,7 @@ class RelayStreamTrack(MediaStreamTrack):
 
         if self._frame is None:
             self.stop()
-            raise MediaStreamError
+            raise MediaStreamError("RelayStreamTrack received end of stream")
         return self._frame
 
     def stop(self) -> None:

--- a/src/aiortc/mediastreams.py
+++ b/src/aiortc/mediastreams.py
@@ -86,7 +86,7 @@ class AudioStreamTrack(MediaStreamTrack):
         :class:`AudioStreamTrack` to provide a useful implementation.
         """
         if self.readyState != "live":
-            raise MediaStreamError
+            raise MediaStreamError("AudioStreamTrack is not in 'live' state")
 
         sample_rate = 8000
         samples = int(AUDIO_PTIME * sample_rate)
@@ -120,7 +120,7 @@ class VideoStreamTrack(MediaStreamTrack):
 
     async def next_timestamp(self) -> tuple[int, fractions.Fraction]:
         if self.readyState != "live":
-            raise MediaStreamError
+            raise MediaStreamError("VideoStreamTrack is not in 'live' state")
 
         if hasattr(self, "_timestamp"):
             self._timestamp += int(VIDEO_PTIME * VIDEO_CLOCK_RATE)

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -829,7 +829,11 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         # configure direction
         for t in self.__transceivers:
             if description.type in ["answer", "pranswer"]:
-                t._setCurrentDirection(and_direction(t.direction, t._offerDirection))
+                if t._offerDirection is None:
+                    # If we never got an offer direction, use our preferred direction
+                    t._setCurrentDirection(t.direction)
+                else:
+                    t._setCurrentDirection(and_direction(t.direction, t._offerDirection))
 
         # gather candidates
         await self.__gather()

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -201,12 +201,12 @@ class RemoteStreamTrack(MediaStreamTrack):
         Receive the next frame.
         """
         if self.readyState != "live":
-            raise MediaStreamError
+            raise MediaStreamError("RemoteStreamTrack is not in 'live' state")
 
         frame = await self._queue.get()
         if frame is None:
             self.stop()
-            raise MediaStreamError
+            raise MediaStreamError("RemoteStreamTrack is not in 'live' state")
         return frame
 
 

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -299,6 +299,9 @@ class RTCRtpSender:
         if not self._enabled:
             return None
 
+        if not data:
+            return None
+
         audio_level = None
 
         if self.__encoder is None:


### PR DESCRIPTION
- Add descriptive error messages to MediaStreamError raises in media tracks
- Handle case where RTCRtpSender.send() is called with None data
- Fix transceiver direction handling when no offer direction is set
- Update version to 1.13.0a2